### PR TITLE
fix(libre-sys): upgrade bindgen to 0.72 for Rust 2024 edition compati…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,9 +252,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags",
  "cexpr",

--- a/external/bladerf-sys/Cargo.toml
+++ b/external/bladerf-sys/Cargo.toml
@@ -17,7 +17,7 @@ doctest = false
 
 [build-dependencies]
 pkg-config = "0.3"
-bindgen = "0.71"
+bindgen = "0.72"
 
 [lints]
 workspace = true

--- a/external/libre-sys/Cargo.toml
+++ b/external/libre-sys/Cargo.toml
@@ -18,7 +18,7 @@ required = []
 doctest = false
 
 [build-dependencies]
-bindgen = "0.71"
+bindgen = "0.72"
 cc = "1"
 pkg-config = "0.3"
 

--- a/external/libre-sys/src/lib.rs
+++ b/external/libre-sys/src/lib.rs
@@ -1,6 +1,11 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
+// Suppress lints on bindgen-generated code that hasn't caught up with Rust 1.95+.
+// See https://rust-lang.github.io/rust-bindgen/tutorial-4.html
+#![allow(unnecessary_transmutes)]
+#![allow(clippy::missing_safety_doc)]
+#![allow(clippy::ptr_offset_with_cast)]
 
 //!
 //! Low-level bindings to Baresip's `libre`/`re` C library.

--- a/external/limesuite-sys/Cargo.toml
+++ b/external/limesuite-sys/Cargo.toml
@@ -17,7 +17,7 @@ doctest = false
 
 [build-dependencies]
 pkg-config = "0.3"
-bindgen = "0.71"
+bindgen = "0.72"
 
 [lints]
 workspace = true

--- a/external/uhd-sys/Cargo.toml
+++ b/external/uhd-sys/Cargo.toml
@@ -19,7 +19,7 @@ doctest = false
 
 [build-dependencies]
 pkg-config = "0.3"
-bindgen = "0.71"
+bindgen = "0.72"
 
 [lints]
 workspace = true


### PR DESCRIPTION
…bility

Bindgen 0.71 generated code that violated unsafe_op_in_unsafe_fn (required by edition 2024). Upgrading to 0.72 fixes that. Remaining cosmetic lints (unnecessary_transmutes, ptr_offset_with_cast, missing_safety_doc) are suppressed per standard practice for machine-generated FFI bindings.

Fixes #2 